### PR TITLE
Documentation

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -2,8 +2,23 @@ MAP Client Documentation
 ========================
 
 The documentation for MAP Client is written for Sphinx in reStructuredText.  It is easiest to read the documentation in
-a Sphinx processed form.  Refer to the Sphinx documentation for the details on turning reStructuredText into a processed
+a Sphinx processed form. Refer to the Sphinx documentation for the details on turning reStructuredText into a processed
 form that best suits your requirements.
 
 A processed form of the documentation is available of `readthedocs <https://rtfd.org>`_.  The reStructuredText files
 in the repository are for making additions or changes and not general consumption.
+
+Should the user desire to make any changes to the documentation, it is relatively easy to re-generate the html files from
+the reStructuredText documentation using Sphinx. This process is described as follows. On the command line, set the current
+directory to the location of the :code:`docs` directory on the user's drive::
+
+    cd <Local Directory>\mapclient\docs
+
+Then, run the following command::
+
+    make html
+
+The updated html files can then be found in :code:`..\docs\_build\html`. :code:`index.html` is the entry to the documentation.
+
+If the user encounters any issues with the make command: Windows users should be using cmd.exe rather than any command line
+alternatives; macOS and Linux users should ensure that (GNU) make is installed.

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -21,4 +21,5 @@ Then, run the following command::
 The updated html files can then be found in :code:`..\docs\_build\html`. :code:`index.html` is the entry to the documentation.
 
 If the user encounters any issues with the make command: Windows users should be using cmd.exe rather than any command line
-alternatives; macOS and Linux users should ensure that (GNU) make is installed.
+alternatives; macOS and Linux users should ensure that (GNU) make is installed. Otherwise, the problem is likely to be related
+to the installation of Sphinx.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -120,7 +120,7 @@ html_theme_path = ['resources']
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['resources/_static']
+html_static_path = ['resources/rtd_theme/static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/docs/developer/MAP-development-gitbranching.rst
+++ b/docs/developer/MAP-development-gitbranching.rst
@@ -44,13 +44,9 @@ The other role for the PQM is to merge a finalising branch into master.  The fin
 Centralised Workflow (using distributed VCS)
 ============================================
 
-The repository setup for this workflow makes use of the notion of a central definitive repository.  This concept is just
- a notion as there is no such thing (at a technical level) as a central repository in a DVCS like Git.  We will refer to
-  this central repository as the **prime** repostiory.
+The repository setup for this workflow makes use of the notion of a central definitive repository.  This concept is just a notion as there is no such thing (at a technical level) as a central repository in a DVCS like Git.  We will refer to this central repository as the **prime** repostiory.
 
-Official releases are made from the master branch in *prime*.  This process is managed by the PQM which goes through the
- process of a release in a systematic way.  Making in release in a systematic way is intended to make the task of
-creating a release easier and consistent.
+Official releases are made from the master branch in *prime*.  This process is managed by the PQM which goes through the process of a release in a systematic way.  Making in release in a systematic way is intended to make the task of creating a release easier and consistent.
 
 Main Branches
 =============

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/manual/MAP-install-setup.rst
+++ b/docs/manual/MAP-install-setup.rst
@@ -9,9 +9,9 @@ The MAP Client software is a Python application that uses the PySide Qt library 
 
 The `Installation`_ section details getting the MAP Client and it's dependencies installed on your system.
 There are two main ways of getting the MAP Client installed on your operating system.  This document will cover both of those methods.
-For users and plugin developers the suggested method is to `Install Using Pip`_, for developers of the MAP Client framework the suggested method is to `Install Using Bazaar`_.
+For users and plugin developers the suggested method is to `Install Using Pip`_.
 
-The `Install Using Pip`_ method is covered first followed by the instructions on how to `Install Using Pre-Built Binary`_.
+The `Install Using Pre-Built Binary`_ method is covered first followed by the instructions on how to `Install Using Pip`_.
 For most operating systems Python is already installed but for some, most notably Windows based operating systems, it is not.  For instructions on installing Python for Windows based operating systems see the `Installing Python on Windows`_ section.
 
 The `Setup`_ section details getting the MAP Client setup with external plugins.
@@ -31,7 +31,7 @@ Download and install the package.
 
 
 Install Using Pip
-=================
+-----------------
 
 Pip is a tool for installing and managing Python packages.  It is particularly suited for the installation and management of source distributions of Python software, of which the MAP Client is one.  The downside to using pip is that it is not great for installing binary packages, and there is one such binary package that the MAP Client requires, namely PySide.  This creates something of a problem for the installation of the MAP Client.  To make the installation via pip as easy as possible we must do some of the installation manually.
 
@@ -70,7 +70,7 @@ which should result in an application window similar to that shown below.
 The MAP Client relies heavily on plugins to do anything interesting, you can either create these yourself or add already available ones to your application by downloading them and using the Plugin Manager Tool in the MAP Client, read the documents :ref:`MAP-feature-demonstration` and :ref:`MAP-plugin-wizard` to learn more.
 
 Install Using Git
-=================
+-----------------
 
 Git is a distributed revision control tool.  It is used by Github for open source project hosting where the MAP Client source code is situated.  To get 'git' use you systems package management system to install it.  If you are on windows then download and install it from:
 
@@ -81,7 +81,7 @@ and clone the source code and manually setup the required software::
     git clone https://github.com/MusculoskeletalAtlasProject/mapclient.git
 
 Installing Pip
-==============
+--------------
 
 Pip is a tool for installing and managing Python packages.  It relies on setuptools to work, first you must install setuptools which has very good instructions available here
 
@@ -98,7 +98,7 @@ If this command prints out the version of setuptools you have installed then you
 otherwise you will probably need to adjust the PATH system variable so that the easy_install application is available. 
 
 Installing Python on Windows
-============================
+----------------------------
 
 This section is for setting up Python on Windows as other operating systems supported by the MAP Client already have Python available.  The MAP Client framework is written in :term:`Python` and is designed to work with Python 2 and Python 3.  The MAP Client framework is tested against Python 2.6, Python 2.7 and Python 3.3 and should work with any of these Python libraries.
 
@@ -118,7 +118,7 @@ Setup
 -----
 
 External Plugins
-================
+----------------
 
 .. _github orginisation: https://github.com/mapclient-plugins
 
@@ -127,7 +127,7 @@ The installation of external MAP Client plugins is a two step process.  The firs
 There is a `github orginisation`_ which has a collection of MAP Client plugins.  Some of the plugins here are more advanced and have a dependency on the Zinc and PyZinc libraries.  To use these plugins please read the `Zinc and PyZinc`_ section on how to setup them up.
 
 Zinc and PyZinc
-===============
+---------------
 
 `Zinc <http://physiomeproject.org/software/opencmiss/zinc/>`_ is an advanced field manipulation and visualisation library and PyZinc provides :term:`Python` bindings to the Zinc library.  The MAP client is able to make use of Zinc for advanced visualisation and image processing steps through PyZinc.  Binaries for Zinc and PyZinc are available from `here <http://physiomeproject.org/software/opencmiss/zinc/download/>`__ for Linux, Windows, and OS X.
 

--- a/docs/manual/MAP-plugin-authoring.rst
+++ b/docs/manual/MAP-plugin-authoring.rst
@@ -17,16 +17,16 @@ The steps for adding a skeleton plugin to a git repository is
    #. cd into teh directory where skeleton plugin was created
    #. Link the repository and make the first commit with the following commands::
    
-      git init .
-      git remote add origin <repository location from above>
-      git pull -u origin master
-      git add .
-      git commit -m "Initial commit of skeleton step."
-      git push -u origin master
+        git init .
+        git remote add origin <repository location from above>
+        git pull -u origin master
+        git add .
+        git commit -m "Initial commit of skeleton step."
+        git push -u origin master
       
    #. [Optional] If using eclipse add the following lines to the .gitignore file::
    
-      # Eclipse PyDev
-      .project
-      .pydevproject
+        # Eclipse PyDev
+        .project
+        .pydevproject
 

--- a/docs/manual/index.rst
+++ b/docs/manual/index.rst
@@ -13,6 +13,7 @@ This is the MAP Client manual for MAP Client version |version|.
    MAP-feature-demonstration
    MAP-plugin
    MAP-plugin-wizard
+   MAP-plugin-authoring
    MAP-tutorial-create
    MAP-tutorial-plugin
    


### PR DESCRIPTION
Updated the documentation README to instruct users how to re-generate html files from the .rst documentation included with the MAP Client source code. A few minor changes have also been made to the documentation to fix a number of Sphinx build warnings, and to make the building process as easy as possible.