### PR TITLE
Updated Step IDs to be click-editable.

### DIFF
--- a/src/mapclient/view/workflow/workflowgraphicsitems.py
+++ b/src/mapclient/view/workflow/workflowgraphicsitems.py
@@ -541,11 +541,6 @@ class StepText(QtWidgets.QGraphicsTextItem):
     def setText(self, text):
         self.setPlainText(text)
 
-    def boundingRect(self):
-        br = super(StepText, self).boundingRect()
-        adjust = 0.0
-        return br.adjusted(-adjust, -adjust, adjust, adjust)
-
     def paint(self, painter, option, widget):
 
         painter.eraseRect(self.boundingRect())

--- a/src/mapclient/view/workflow/workflowgraphicsitems.py
+++ b/src/mapclient/view/workflow/workflowgraphicsitems.py
@@ -514,14 +514,36 @@ class StepPort(QtWidgets.QGraphicsEllipseItem):
 
         return QtWidgets.QGraphicsItem.itemChange(self, change, value)
 
-
-class StepText(QtWidgets.QGraphicsSimpleTextItem):
+class StepText(QtWidgets.QGraphicsTextItem):
 
     Type = QtWidgets.QGraphicsItem.UserType + 4
 
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.setTextInteractionFlags(QtCore.Qt.TextEditable | QtCore.Qt.TextSelectableByMouse | QtCore.Qt.TextSelectableByKeyboard)
+        self._make_connections()
+
+    def _make_connections(self):
+        self.document().contentsChanged.connect(self.adjust)
+
+    def focusOutEvent(self, event):
+        super().focusOutEvent(event)
+        self.scene().setConfigureNode(self.parentItem())
+        step = self.parentItem().metaItem().getStep()
+        step.setIdentifier(self.toPlainText())
+        step._configuredObserver()
+
+    def adjust(self):
+        parent_x = self.parentItem().boundingRect().center().x()
+        offset = int(self.boundingRect().width() / 2)
+        self.setX(parent_x - offset)
+
+    def setText(self, text):
+        self.setPlainText(text)
+
     def boundingRect(self):
         br = super(StepText, self).boundingRect()
-        adjust = 2.0
+        adjust = 0.0
         return br.adjusted(-adjust, -adjust, adjust, adjust)
 
     def paint(self, painter, option, widget):

--- a/src/mapclient/view/workflow/workflowgraphicsview.py
+++ b/src/mapclient/view/workflow/workflowgraphicsview.py
@@ -130,7 +130,12 @@ class WorkflowGraphicsView(QtWidgets.QGraphicsView):
             self.connectNodes(self._selectedNodes[0], self._selectedNodes[1])
 
     def keyPressEvent(self, event):
+        QtWidgets.QGraphicsView.keyPressEvent(self, event)
         if event.key() == QtCore.Qt.Key_Backspace or event.key() == QtCore.Qt.Key_Delete:
+
+            if self.scene().focusItem():
+                return
+
             command = CommandRemove(self.scene(), self.scene().selectedItems())
             self._undoStack.push(command)
             event.accept()


### PR DESCRIPTION
The StepText class now inherits from QGraphicsTextItem rather than QGraphicsSimpleTextItem. Because of this the user is now able to edit step identifier labels by clicking them, rather than having to open each step's configuration dialog.