### PR TITLE
Workflow control

### DIFF
--- a/src/mapclient/core/managers/workflowmanager.py
+++ b/src/mapclient/core/managers/workflowmanager.py
@@ -134,6 +134,9 @@ class WorkflowManager(object):
     def abort_execution(self):
         self._scene.abort_execution()
 
+    def set_workflow_direction(self, direction):
+        self._scene.set_workflow_direction(direction)
+
     def canExecute(self):
         return self._scene.canExecute()
 

--- a/src/mapclient/core/managers/workflowmanager.py
+++ b/src/mapclient/core/managers/workflowmanager.py
@@ -131,6 +131,9 @@ class WorkflowManager(object):
     def execute(self):
         self._scene.execute()
 
+    def abort_execution(self):
+        self._scene.abort_execution()
+
     def canExecute(self):
         return self._scene.canExecute()
 

--- a/src/mapclient/core/workflow/workflowdependencygraph.py
+++ b/src/mapclient/core/workflow/workflowdependencygraph.py
@@ -152,6 +152,9 @@ class WorkflowDependencyGraph(object):
         can = len(configured) == len(self._topological_order) and len(self._topological_order) >= 0
         return can and self._current == -1
 
+    def abort(self):
+        self._current = -1
+
     def execute(self):
         self._current += 1
         if self._current >= len(self._topological_order):

--- a/src/mapclient/core/workflow/workflowdependencygraph.py
+++ b/src/mapclient/core/workflow/workflowdependencygraph.py
@@ -101,6 +101,7 @@ class WorkflowDependencyGraph(object):
         self._reverse_dependency_graph = {}
         self._topological_order = []
         self._current = -1
+        self._direction = 1
         self._finished_callback = None
 
     def _find_all_connected_nodes(self):
@@ -155,12 +156,18 @@ class WorkflowDependencyGraph(object):
     def abort(self):
         self._current = -1
 
+    def set_direction(self, direction):
+        self._direction = 1 if direction else -1
+
     def execute(self):
-        self._current += 1
+        self._current += self._direction
         if self._current >= len(self._topological_order):
             self._current = -1
             if callable(self._finished_callback):
-                self._finished_callback()
+                self._finished_callback(True)
+        elif self._current == -1:
+            if callable(self._finished_callback):
+                self._finished_callback(False)
         else:
             # Form input requirements
             current_node = self._topological_order[self._current]

--- a/src/mapclient/core/workflow/workflowscene.py
+++ b/src/mapclient/core/workflow/workflowscene.py
@@ -285,6 +285,9 @@ class WorkflowScene(object):
     def execute(self):
         self._dependencyGraph.execute()
 
+    def abort_execution(self):
+        self._dependencyGraph.abort()
+
     def register_finished_workflow_callback(self, callback):
         self._dependencyGraph.set_finished_callback(callback)
 

--- a/src/mapclient/core/workflow/workflowscene.py
+++ b/src/mapclient/core/workflow/workflowscene.py
@@ -288,6 +288,9 @@ class WorkflowScene(object):
     def abort_execution(self):
         self._dependencyGraph.abort()
 
+    def set_workflow_direction(self, direction):
+        self._dependencyGraph.set_direction(direction)
+
     def register_finished_workflow_callback(self, callback):
         self._dependencyGraph.set_finished_callback(callback)
 

--- a/src/mapclient/view/mainwindow.py
+++ b/src/mapclient/view/mainwindow.py
@@ -264,6 +264,11 @@ class MainWindow(QtWidgets.QMainWindow):
             self.set_current_undo_redo_stack(self._workflowWidget.undoRedoStack())
         self.model().workflowManager().execute()
 
+    def abort_execution(self):
+        self.model().workflowManager().abort_execution()
+        self.set_current_widget(self._workflowWidget)
+        self.set_current_undo_redo_stack(self._workflowWidget.undoRedoStack())
+
     @set_wait_cursor
     def set_current_widget(self, widget):
         if self._ui.stackedWidget.indexOf(widget) <= 0:

--- a/src/mapclient/view/mainwindow.py
+++ b/src/mapclient/view/mainwindow.py
@@ -269,6 +269,9 @@ class MainWindow(QtWidgets.QMainWindow):
         self.set_current_widget(self._workflowWidget)
         self.set_current_undo_redo_stack(self._workflowWidget.undoRedoStack())
 
+    def set_workflow_direction(self, direction):
+        self.model().workflowManager().set_workflow_direction(direction)
+
     @set_wait_cursor
     def set_current_widget(self, widget):
         if self._ui.stackedWidget.indexOf(widget) <= 0:

--- a/src/mapclient/view/workflow/workflowwidget.py
+++ b/src/mapclient/view/workflow/workflowwidget.py
@@ -118,6 +118,8 @@ class WorkflowWidget(QtWidgets.QWidget):
             self.action_Open.setEnabled(widget_visible)
             self.action_Execute.setEnabled(workflow_open and widget_visible)
             self.action_Continue.setEnabled(workflow_open and not widget_visible)
+            self.action_Reverse.setEnabled(workflow_open and not widget_visible)
+            self.action_Abort.setEnabled(workflow_open and not widget_visible)
             self.action_ZoomIn.setEnabled(widget_visible)
 
     def updateStepTree(self):
@@ -143,6 +145,10 @@ class WorkflowWidget(QtWidgets.QWidget):
     def hideEvent(self, *args, **kwargs):
         self._update_ui()
         return QtWidgets.QWidget.hideEvent(self, *args, **kwargs)
+
+    @handle_runtime_error
+    def _abort_execution(self):
+        self._main_window.abort_execution()
 
     @handle_runtime_error
     def executeNext(self):
@@ -175,6 +181,12 @@ class WorkflowWidget(QtWidgets.QWidget):
 
     def continueWorkflow(self):
         self.executeNext()
+
+    def _abort_workflow(self):
+        self._abort_execution()
+
+    def _reverse_workflow_direction(self):
+        print("reverse workflow direction")
 
     def identifierOccursCount(self, identifier):
         return self._main_window.model().workflowManager().identifierOccursCount(identifier)
@@ -636,6 +648,12 @@ class WorkflowWidget(QtWidgets.QWidget):
         self.action_Continue = QtWidgets.QAction('&Continue', menu_workflow)
         self._set_action_properties(self.action_Continue, 'action_Continue', self.continueWorkflow, 'Ctrl+T',
                                     'Continue executing Workflow')
+        self.action_Reverse = QtWidgets.QAction('Reverse', menu_workflow)
+        self._set_action_properties(self.action_Reverse, 'action_Reverse', self._reverse_workflow_direction, '',
+                                    'Reverse Workflow Direction')
+        self.action_Abort = QtWidgets.QAction('Abort', menu_workflow)
+        self._set_action_properties(self.action_Abort, 'action_Abort', self._abort_workflow, '',
+                                    'Abort Workflow')
 
         self.action_ZoomIn = QtWidgets.QAction('Zoom In', menu_view)
         self._set_action_properties(self.action_ZoomIn, 'action_ZoomIn', self.zoom_in, 'Ctrl++',
@@ -665,3 +683,5 @@ class WorkflowWidget(QtWidgets.QWidget):
 
         menu_workflow.addAction(self.action_Execute)
         menu_workflow.addAction(self.action_Continue)
+        menu_workflow.addAction(self.action_Reverse)
+        menu_workflow.addAction(self.action_Abort)

--- a/src/mapclient/view/workflow/workflowwidget.py
+++ b/src/mapclient/view/workflow/workflowwidget.py
@@ -117,7 +117,7 @@ class WorkflowWidget(QtWidgets.QWidget):
             self.action_NewPMR.setEnabled(widget_visible)
             self.action_Open.setEnabled(widget_visible)
             self.action_Execute.setEnabled(workflow_open and widget_visible)
-            self.action_Continue.setEnabled(workflow_open and not widget_visible)
+            # self.action_Continue.setEnabled(workflow_open and not widget_visible)
             self.action_Reverse.setEnabled(workflow_open and not widget_visible)
             self.action_Abort.setEnabled(workflow_open and not widget_visible)
             self.action_ZoomIn.setEnabled(widget_visible)
@@ -159,7 +159,6 @@ class WorkflowWidget(QtWidgets.QWidget):
 
     def executeWorkflow(self):
         wfm = self._main_window.model().workflowManager()
-        wfm.register_finished_workflow_callback(self._workflow_finished)
         errors = []
 
         if wfm.isModified():
@@ -168,9 +167,7 @@ class WorkflowWidget(QtWidgets.QWidget):
         if not wfm.canExecute():
             errors.append('Not all steps in the workflow have been successfully configured.')
 
-        if not errors:
-            self.executeNext()
-        else:
+        if errors:
             errors_str = '\n'.join(
                 ['  %d. %s' % (i + 1, e) for i, e in enumerate(errors)])
             error_msg = ('The workflow could not be executed for the '
@@ -178,15 +175,23 @@ class WorkflowWidget(QtWidgets.QWidget):
                              len(errors) > 1 and 's' or '', errors_str,
                          ))
             QtWidgets.QMessageBox.critical(self, 'Workflow Execution', error_msg, QtWidgets.QMessageBox.Ok)
+        else:
+            wfm.register_finished_workflow_callback(self._workflow_finished)
+            self.executeNext()
 
     def continueWorkflow(self):
         self.executeNext()
 
     def _abort_workflow(self):
         self._abort_execution()
+        self._reset_workflow_direction()
 
     def _reverse_workflow_direction(self):
-        print("reverse workflow direction")
+        self._main_window.set_workflow_direction(not self.action_Reverse.isChecked())
+
+    def _reset_workflow_direction(self):
+        self.action_Reverse.setChecked(False)
+        self._main_window.set_workflow_direction(True)
 
     def identifierOccursCount(self, identifier):
         return self._main_window.model().workflowManager().identifierOccursCount(identifier)
@@ -202,14 +207,16 @@ class WorkflowWidget(QtWidgets.QWidget):
         if workflowDir:
             self._createNewWorkflow(workflowDir, pmr)
 
-    def _workflow_finished(self):
-        # MessageBox()
-        mb = MessageBox(QtWidgets.QMessageBox.Icon.Information, "Workflow Finished",
-                        "Workflow finished successfully.",
-                        QtWidgets.QMessageBox.Ok | QtWidgets.QMessageBox.Default,
-                        parent=self._main_window)
-        mb.setIconPixmap(QtGui.QPixmap(":/mapclient/images/green_tick.png").scaled(64, 64))
-        mb.exec_()
+    def _workflow_finished(self, successfully):
+        if successfully:
+            mb = MessageBox(QtWidgets.QMessageBox.Icon.Information, "Workflow Finished",
+                            "Workflow finished successfully.",
+                            QtWidgets.QMessageBox.Ok | QtWidgets.QMessageBox.Default,
+                            parent=self._main_window)
+            mb.setIconPixmap(QtGui.QPixmap(":/mapclient/images/green_tick.png").scaled(64, 64))
+            mb.exec_()
+        else:
+            self._reset_workflow_direction()
 
     def _getWorkflowDir(self):
         m = self._main_window.model().workflowManager()
@@ -645,10 +652,11 @@ class WorkflowWidget(QtWidgets.QWidget):
         self.action_Execute = QtWidgets.QAction('E&xecute', menu_workflow)
         self._set_action_properties(self.action_Execute, 'action_Execute', self.executeWorkflow, 'Ctrl+X',
                                     'Execute Workflow')
-        self.action_Continue = QtWidgets.QAction('&Continue', menu_workflow)
-        self._set_action_properties(self.action_Continue, 'action_Continue', self.continueWorkflow, 'Ctrl+T',
-                                    'Continue executing Workflow')
+        # self.action_Continue = QtWidgets.QAction('&Continue', menu_workflow)
+        # self._set_action_properties(self.action_Continue, 'action_Continue', self.continueWorkflow, 'Ctrl+T',
+        #                             'Continue executing Workflow')
         self.action_Reverse = QtWidgets.QAction('Reverse', menu_workflow)
+        self.action_Reverse.setCheckable(True)
         self._set_action_properties(self.action_Reverse, 'action_Reverse', self._reverse_workflow_direction, '',
                                     'Reverse Workflow Direction')
         self.action_Abort = QtWidgets.QAction('Abort', menu_workflow)
@@ -682,6 +690,6 @@ class WorkflowWidget(QtWidgets.QWidget):
         menu_view.insertSeparator(last_view_menu_action)
 
         menu_workflow.addAction(self.action_Execute)
-        menu_workflow.addAction(self.action_Continue)
+        # menu_workflow.addAction(self.action_Continue)
         menu_workflow.addAction(self.action_Reverse)
         menu_workflow.addAction(self.action_Abort)


### PR DESCRIPTION
Add workflow abilities: Abort, and Reverse.
Abort allows the user to exit a workflow immediately from a GUI based step.
The reverse functionality allows a user to traverse the workflow in the reverse direction once the workflow has started.