### PR TITLE
Address workflow step positioning issues

### DIFF
--- a/src/mapclient/core/mainapplication.py
+++ b/src/mapclient/core/mainapplication.py
@@ -40,6 +40,7 @@ class MainApplication(object):
     def __init__(self):
         self._size = QtCore.QSize(600, 400)
         self._pos = QtCore.QPoint(100, 150)
+        self._is_maximized = False
         self._pluginManager = PluginManager()
         self._package_manager = PackageManager()
         self._workflowManager = WorkflowManager(self)
@@ -60,6 +61,12 @@ class MainApplication(object):
 
     def pos(self):
         return self._pos
+
+    def set_maximized(self, is_maximized):
+        self._is_maximized = is_maximized
+
+    def is_maximized(self):
+        return self._is_maximized
 
     def undoManager(self):
         return self._undoManager
@@ -85,6 +92,7 @@ class MainApplication(object):
         settings.beginGroup('MainWindow')
         settings.setValue('size', self._size)
         settings.setValue('pos', self._pos)
+        settings.setValue('is_maximized', self._is_maximized)
         settings.endGroup()
         self._pluginManager.writeSettings(settings)
         self._workflowManager.writeSettings(settings)
@@ -96,6 +104,7 @@ class MainApplication(object):
         settings.beginGroup('MainWindow')
         self._size = settings.value('size', self._size)
         self._pos = settings.value('pos', self._pos)
+        self._is_maximized = settings.value('is_maximized', 'true') == 'true'
         settings.endGroup()
         self._pluginManager.readSettings(settings)
         self._workflowManager.readSettings(settings)

--- a/src/mapclient/core/managers/workflowmanager.py
+++ b/src/mapclient/core/managers/workflowmanager.py
@@ -198,12 +198,6 @@ class WorkflowManager(object):
 
         return self._scene.is_restricted(wf)
 
-    def fit_workflow(self, graphics_view, graphics_scene):
-        """
-        Scales the workflow items to fit into the current window size. This method maintains the aspect ratio of the saved workflow.
-        """
-        self._scene.fit_workflow(graphics_view, graphics_scene)
-
     def load(self, location):
         """
         Open a workflow from the given location.

--- a/src/mapclient/core/managers/workflowmanager.py
+++ b/src/mapclient/core/managers/workflowmanager.py
@@ -90,12 +90,9 @@ class WorkflowManager(object):
 
         return self._title
 
-    def updateLocation(self, location):
+    def set_location(self, location):
         self._location = location
         return self._scene.updateWorkflowLocation(location)
-
-    def setLocation(self, location):
-        self._location = location
 
     def location(self):
         return self._location
@@ -169,7 +166,7 @@ class WorkflowManager(object):
         if not os.path.exists(location):
             raise WorkflowError('Location %s does not exist.' % location)
 
-        self._location = location
+        self.set_location(location)
         wf = _getWorkflowConfiguration(location)
         wf.setValue('version', info.VERSION_STRING)
         self._scene.clear()
@@ -230,7 +227,7 @@ class WorkflowManager(object):
         if not _compatible_versions(workflow_version, application_version):
             pass  # should already have thrown an exception
 
-        self._location = location
+        self.set_location(location)
         if self._scene.is_loadable(wf):
             self._scene.restrict_plugins(wf)
             self._scene.load_state(wf)
@@ -296,7 +293,7 @@ class WorkflowManager(object):
         """
         Close the current workflow
         """
-        self._location = ''
+        self.set_location('')
         self._saveStateIndex = self._currentStateIndex = 0
 
     def isWorkflowOpen(self):

--- a/src/mapclient/core/workflow/workflowscene.py
+++ b/src/mapclient/core/workflow/workflowscene.py
@@ -161,27 +161,6 @@ class WorkflowScene(object):
         step_names = self._read_step_names(ws)
         restrict_plugins(step_names)
 
-    def fit_workflow(self, graphics_view, graphics_scene):
-        """
-        Scales the workflow items to fit into the current window size. This method maintains the aspect ratio of the saved workflow.
-        """
-        view_size = graphics_view.size()
-        scene_size = graphics_scene.sceneRect()
-
-        # -70 from both to account for step item width. +22 to scene to account for scene border.
-        sf_x = (view_size.width() - 70) / (scene_size.width() - 48)
-        sf_y = (view_size.height() - 70) / (scene_size.height() - 48)
-
-        if sf_x != 1 or sf_y != 1:
-            for item in self.items():
-                if isinstance(item, MetaStep):
-                    x = sf_x * item.getPos().x()
-                    y = sf_y * item.getPos().y()
-                    item.setPos(QtCore.QPointF(x, y))
-
-            graphics_scene.setSceneRect(graphics_view.rect())
-            graphics_scene.updateModel()
-
     def doStepReport(self, ws):
         report = {}
         ws.beginGroup('nodes')

--- a/src/mapclient/view/mainwindow.py
+++ b/src/mapclient/view/mainwindow.py
@@ -67,6 +67,8 @@ class MainWindow(QtWidgets.QMainWindow):
     def showEvent(self, event):
         self.resize(self._model.size())
         self.move(self._model.pos())
+        if self._model.is_maximized():
+            self.showMaximized()
 
     def _setup_menus(self):
         """
@@ -307,6 +309,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self._model.setSize(self.size())
         self._model.setPos(self.pos())
+        self._model.set_maximized(self.isMaximized())
         self._model.writeSettings()
         QtGui.QGuiApplication.quit()
 

--- a/src/mapclient/view/workflow/workflowgraphicsview.py
+++ b/src/mapclient/view/workflow/workflowgraphicsview.py
@@ -58,9 +58,6 @@ class WorkflowGraphicsView(QtWidgets.QGraphicsView):
         self.setCacheMode(QtWidgets.QGraphicsView.CacheBackground)
         self.setRenderHint(QtGui.QPainter.Antialiasing)
 
-        grid_pic = QtGui.QPixmap(':/workflow/images/grid.png')
-        self._grid_brush = QtGui.QBrush(grid_pic)
-
         #        self.setTransformationAnchor(QtGui.QGraphicsView.AnchorUnderMouse)
         #        self.setResizeAnchor(QtGui.QGraphicsView.AnchorViewCenter)
 
@@ -365,8 +362,25 @@ class WorkflowGraphicsView(QtWidgets.QGraphicsView):
         if bottomShadow.intersects(rect) or bottomShadow.contains(rect):
             painter.fillRect(bottomShadow, QtCore.Qt.darkGray)
 
-        painter.setBrush(self._grid_brush)  # QtCore.Qt.NoBrush
-        painter.drawRect(sceneRect)
+        self._draw_grid(sceneRect, painter)
+
+    def _draw_grid(self, scene_rect, painter):
+        self.grid_pen = QtGui.QPen(QtGui.QColor("lightblue"))
+        painter.setPen(self.grid_pen)
+
+        top = int(scene_rect.y())
+        left = int(scene_rect.x())
+        bottom = int(scene_rect.y() + scene_rect.height())
+        right = int(scene_rect.x() + scene_rect.width())
+        step = 10
+
+        for y in range(top, bottom, step):
+            painter.drawLine(left, y, right, y)
+        for x in range(left, right, step):
+            painter.drawLine(x, top, x, bottom)
+
+        painter.setPen(QtGui.QPen(QtGui.QColor("black")))
+        painter.drawRect(scene_rect)
 
     def dropEvent(self, event):
         if event.mimeData().hasFormat("image/x-workflow-step(s)"):

--- a/src/mapclient/view/workflow/workflowgraphicsview.py
+++ b/src/mapclient/view/workflow/workflowgraphicsview.py
@@ -448,6 +448,7 @@ class WorkflowGraphicsView(QtWidgets.QGraphicsView):
                 self._graphics_initialised = True
 
             scene.setSceneRect(10, 10, (view_rect.width() - 20) / self._graphics_scale_factor, (view_rect.height() - 20) / self._graphics_scale_factor)
+            self.reposition_steps()
 
     def _unscale_view(self, scale_factor):
         self._graphics_scale_factor *= scale_factor
@@ -473,6 +474,7 @@ class WorkflowGraphicsView(QtWidgets.QGraphicsView):
         scale_factor = math.pow(2.0, -delta / 240.0)
         self.scale(scale_factor, scale_factor)
         self._unscale_view(scale_factor)
+        self.view_all()
 
     def reset_zoom(self):
         reverse_sf = 1 / self._graphics_scale_factor
@@ -482,49 +484,81 @@ class WorkflowGraphicsView(QtWidgets.QGraphicsView):
         self._graphics_scale_factor = 1.0
         self.resetTransform()
 
-    def view_all(self):
+    def reposition_steps(self):
         scene_rect = self.sceneRect()
-        scene_rect.setWidth(scene_rect.width() - 66)
-        scene_rect.setHeight(scene_rect.height() - 66)
         for item in self.items():
             if isinstance(item, Node):
-                if not scene_rect.contains(item.pos()):
-                    self.reset_view()
-                    break
+                x = item.x()
+                if x > (scene_rect.right() - 116):
+                    x = scene_rect.right() - 116
+                y = item.y()
+                if y > (scene_rect.bottom() - 116):
+                    y = scene_rect.bottom() - 116
+
+                if x != item.x() or y != item.y():
+                    item.setPos(QtCore.QPointF(x, y))
+
+    def view_all(self):
+        bounding_rect = self.nodes_bounding_rect()
+        scene_rect = self.sceneRect()
+
+        # This includes 50px of whitespace on each side of the workflow items. Subtract 68 to account for step-icon width.
+        sf_x = 1
+        if (bounding_rect.right()) > (scene_rect.right() - 116):
+            sf_x = (scene_rect.right() - 116) / bounding_rect.right()
+        sf_y = 1
+        if bounding_rect.bottom() > (scene_rect.bottom() - 116):
+            sf_y = (scene_rect.bottom() - 116) / bounding_rect.bottom()
+
+        if sf_x != 1 or sf_y != 1:
+            self.scale_workflow(bounding_rect, sf_x, sf_y)
 
     def reset_view(self):
+        bounding_rect = self.nodes_bounding_rect()
+        scene_rect = self.sceneRect()
+
+        # This includes 50px of whitespace on each side of the workflow items. Subtract 68 to account for step-icon width.
+        sf_x = (scene_rect.width() - 168) / bounding_rect.width()
+        sf_y = (scene_rect.height() - 168) / bounding_rect.height()
+
+        self.reset_workflow_view(bounding_rect, sf_x, sf_y)
+
+    def nodes_bounding_rect(self):
         point_array = [[], []]
         for item in self.items():
             if isinstance(item, Node):
                 point_array[0].append(item.x())
                 point_array[1].append(item.y())
-        bounding_rect = QtCore.QRectF(
-            QtCore.QPointF(min(point_array[0]), min(point_array[1])),
-            QtCore.QPointF(max(point_array[0]), max(point_array[1]))
-        )
 
-        # Calculate the scale factors needed to fit the entire workflow in the scene.
-        # This includes 100px of whitespace on each side of the workflow items. Subtract 68 to account for step-icon width.
-        scene_rect = self.sceneRect()
-        sf_x = (scene_rect.width() - 268) / bounding_rect.width()
-        sf_y = (scene_rect.height() - 268) / bounding_rect.height()
+        if point_array[0]:
+            return QtCore.QRectF(
+                QtCore.QPointF(min(point_array[0]), min(point_array[1])),
+                QtCore.QPointF(max(point_array[0]), max(point_array[1]))
+            )
+        else:
+            return QtCore.QRectF(0, 0, 0, 0)
 
+    def scale_workflow(self, bounding_rect, sf_x, sf_y):
         # Scale the workflow item positions. Add 12 to account for subtracting the view border before scaling.
         self._undoStack.beginMacro('Move Step(s)')
         for item in self.items():
             if isinstance(item, Node):
-                x = ((item.x() - bounding_rect.x()) * sf_x) + 112
-                y = ((item.y() - bounding_rect.y()) * sf_y) + 112
-                self._undoStack.push(CommandMove(item, item.pos(), QtCore.QPointF(x, y)))
+                x = item.x()
+                if sf_x != 1:
+                    x = ((x - 12) * sf_x) + 12
+                y = item.y()
+                if sf_y != 1:
+                    y = ((y - 12) * sf_y) + 12
+
+                if x != item.x() or y != item.y():
+                    self._undoStack.push(CommandMove(item, item.pos(), QtCore.QPointF(x, y)))
         self._undoStack.endMacro()
 
-    def _old_scale_view(self, scale_factor):
-        factor = self.matrix().scale(scale_factor, scale_factor).mapRect(QtCore.QRectF(0, 0, 1, 1)).width()
-
-        if factor < 0.07 or factor > 100:
-            return
-
-        transformation_anchor = self.transformationAnchor()
-        self.setTransformationAnchor(QtWidgets.QGraphicsView.AnchorUnderMouse)
-        self.scale(scale_factor, scale_factor)
-        self.setTransformationAnchor(transformation_anchor)
+    def reset_workflow_view(self, bounding_rect, sf_x, sf_y):
+        self._undoStack.beginMacro('Move Step(s)')
+        for item in self.items():
+            if isinstance(item, Node):
+                x = ((item.x() - bounding_rect.x()) * sf_x) + 62
+                y = ((item.y() - bounding_rect.y()) * sf_y) + 62
+                self._undoStack.push(CommandMove(item, item.pos(), QtCore.QPointF(x, y)))
+        self._undoStack.endMacro()

--- a/src/mapclient/view/workflow/workflowgraphicsview.py
+++ b/src/mapclient/view/workflow/workflowgraphicsview.py
@@ -459,20 +459,28 @@ class WorkflowGraphicsView(QtWidgets.QGraphicsView):
 
     def wheelEvent(self, event):
         if event.modifiers() == QtCore.Qt.ControlModifier:
-            scale_factor = math.pow(2.0, -event.angleDelta().y() / 240.0)
-            # original_transformation_anchor = self.transformationAnchor()
-            # self.setTransformationAnchor(QtWidgets.QGraphicsView.AnchorViewCenter)
-            self.scale(scale_factor, scale_factor)
-            self._unscale_view(scale_factor)
-            # self.setTransformationAnchor(original_transformation_anchor)
+            self.zoom(event.angleDelta().y())
         else:
             super(WorkflowGraphicsView, self).wheelEvent(event)
 
     def zoomIn(self):
-        self.scale(1.2, 1.2)
+        self.zoom(-120)
 
     def zoomOut(self):
-        self.scale(1 / 1.2, 1 / 1.2)
+        self.zoom(120)
+
+    def zoom(self, delta):
+        scale_factor = math.pow(2.0, -delta / 240.0)
+        self.scale(scale_factor, scale_factor)
+        self._unscale_view(scale_factor)
+
+    def reset_zoom(self):
+        reverse_sf = 1 / self._graphics_scale_factor
+        self.scale(reverse_sf, reverse_sf)
+        self._unscale_view(reverse_sf)
+
+        self._graphics_scale_factor = 1.0
+        self.resetTransform()
 
     def _old_scale_view(self, scale_factor):
         factor = self.matrix().scale(scale_factor, scale_factor).mapRect(QtCore.QRectF(0, 0, 1, 1)).width()

--- a/src/mapclient/view/workflow/workflowwidget.py
+++ b/src/mapclient/view/workflow/workflowwidget.py
@@ -624,6 +624,9 @@ class WorkflowWidget(QtWidgets.QWidget):
     def reset_zoom(self):
         self._ui.graphicsView.reset_zoom()
 
+    def reset_view(self):
+        self._ui.graphicsView.reset_view()
+
     def _create_menu_items(self):
         menu_file = self._main_window.get_menu_bar().findChild(QtWidgets.QMenu, 'menu_File')
         menu_workflow = self._main_window.get_menu_bar().findChild(QtWidgets.QMenu, 'menu_Workflow')
@@ -678,6 +681,10 @@ class WorkflowWidget(QtWidgets.QWidget):
         self._set_action_properties(self.action_ResetZoom, 'action_ResetZoom', self.reset_zoom, '',
                                     'Reset Workflow Zoom')
 
+        self.action_ResetView = QtGui.QAction('Reset View', menu_view)
+        self._set_action_properties(self.action_ResetView, 'action_ResetView', self.reset_view, '',
+                                    'Centre and Spread Workflow Items')
+
         menu_new.insertAction(QtGui.QAction(self), self.action_NewPMR)
         menu_new.insertAction(QtGui.QAction(self), self.action_New)
 
@@ -696,6 +703,7 @@ class WorkflowWidget(QtWidgets.QWidget):
         menu_view.addAction(self.action_ZoomIn)
         menu_view.addAction(self.action_ZoomOut)
         menu_view.addAction(self.action_ResetZoom)
+        menu_view.addAction(self.action_ResetView)
         menu_view.insertSeparator(last_view_menu_action)
 
         menu_workflow.addAction(self.action_Execute)

--- a/src/mapclient/view/workflow/workflowwidget.py
+++ b/src/mapclient/view/workflow/workflowwidget.py
@@ -488,6 +488,7 @@ class WorkflowWidget(QtWidgets.QWidget):
             m.scene().setViewParameters(self._ui.graphicsView.getViewParameters())
             m.load(workflow_dir)
             m.setPreviousLocation(workflow_dir)
+            self._ui.graphicsView.setViewParameters(m.scene().getViewParameters())
             self._graphicsScene.updateModel()
             self._ui.graphicsView.setLocation(workflow_dir)
             self._update_ui()

--- a/src/mapclient/view/workflow/workflowwidget.py
+++ b/src/mapclient/view/workflow/workflowwidget.py
@@ -484,12 +484,11 @@ class WorkflowWidget(QtWidgets.QWidget):
     def _load(self, workflow_dir):
         try:
             m = self._main_window.model().workflowManager()
+            m.scene().setViewParameters(self._ui.graphicsView.getViewParameters())
             m.load(workflow_dir)
             m.setPreviousLocation(workflow_dir)
             self._graphicsScene.updateModel()
             self._ui.graphicsView.setLocation(workflow_dir)
-            self._ui.graphicsView.setViewParameters(m.scene().getViewParameters())
-            m.fit_workflow(self._ui.graphicsView, self._graphicsScene)
             self._update_ui()
         except:
             self.close()
@@ -531,7 +530,7 @@ class WorkflowWidget(QtWidgets.QWidget):
     def _updateLocation(self):
         m = self._main_window.model().workflowManager()
         workflow_dir = m.location()
-        if m.updateLocation(workflow_dir):
+        if m.set_location(workflow_dir):
             self._ui.graphicsView.setLocation(workflow_dir)
             self._graphicsScene.updateModel()
 
@@ -541,7 +540,7 @@ class WorkflowWidget(QtWidgets.QWidget):
         workflow_dir = self._getWorkflowDir()
         if workflow_dir:
             m.setPreviousLocation(workflow_dir)
-            m.updateLocation(workflow_dir)
+            m.set_location(workflow_dir)
             self._ui.graphicsView.setLocation(workflow_dir)
             self._graphicsScene.updateModel()
             location_set = True

--- a/src/mapclient/view/workflow/workflowwidget.py
+++ b/src/mapclient/view/workflow/workflowwidget.py
@@ -484,6 +484,7 @@ class WorkflowWidget(QtWidgets.QWidget):
     def _load(self, workflow_dir):
         try:
             m = self._main_window.model().workflowManager()
+            self._ui.graphicsView.reset_zoom()
             m.scene().setViewParameters(self._ui.graphicsView.getViewParameters())
             m.load(workflow_dir)
             m.setPreviousLocation(workflow_dir)
@@ -619,6 +620,9 @@ class WorkflowWidget(QtWidgets.QWidget):
     def zoom_out(self):
         self._ui.graphicsView.zoomOut()
 
+    def reset_zoom(self):
+        self._ui.graphicsView.reset_zoom()
+
     def _create_menu_items(self):
         menu_file = self._main_window.get_menu_bar().findChild(QtWidgets.QMenu, 'menu_File')
         menu_workflow = self._main_window.get_menu_bar().findChild(QtWidgets.QMenu, 'menu_Workflow')
@@ -669,6 +673,9 @@ class WorkflowWidget(QtWidgets.QWidget):
         self.action_ZoomOut = QtGui.QAction('Zoom Out', menu_view)
         self._set_action_properties(self.action_ZoomOut, 'action_ZoomOut', self.zoom_out, 'Ctrl+-',
                                     'Zoom out Workflow')
+        self.action_ResetZoom = QtGui.QAction('Reset Zoom', menu_view)
+        self._set_action_properties(self.action_ResetZoom, 'action_ResetZoom', self.reset_zoom, '',
+                                    'Reset Workflow Zoom')
 
         menu_new.insertAction(QtGui.QAction(self), self.action_NewPMR)
         menu_new.insertAction(QtGui.QAction(self), self.action_New)
@@ -687,6 +694,7 @@ class WorkflowWidget(QtWidgets.QWidget):
 
         menu_view.addAction(self.action_ZoomIn)
         menu_view.addAction(self.action_ZoomOut)
+        menu_view.addAction(self.action_ResetZoom)
         menu_view.insertSeparator(last_view_menu_action)
 
         menu_workflow.addAction(self.action_Execute)


### PR DESCRIPTION
This PR addresses a number of issues related to the scaling and positioning of the MAP-Client workflow steps.

A couple new actions have been added to the MAP-Client's _View_ menu dropdown: a _Reset Zoom_ action which can be used to reset the current zoom scale, and a _Reset View_ action which can be used to scale the positions of the workflow scene items so that all items are in-view and so that the workflow is in the center of and spanning the view panel.

Workflow items are now automatically repositioned when resizing the workflow view area - either by manually dragging the window border to change the window size or by maximizing/un-maximizing. This ensures that workflow items will never be positioned outside of the viewable workflow area.

Some improvements have also been made to the automatic scaling performed when a MAP workflow is loaded into a MAP-Client window with a different size to the window that the workflow was saved in. Additionally, the MAP-Client maximization settings are now also saved to the MAP-Client.ini file when closing the application - and are loaded when reopening the application.

The workflow view now draws grid lines rather than covering the workflow area background with grid PNG images.