### PR TITLE
Fix plugin search functionality

### DIFF
--- a/src/mapclient/view/workflow/workflowsteptreeview.py
+++ b/src/mapclient/view/workflow/workflowsteptreeview.py
@@ -57,8 +57,8 @@ class WorkflowStepTreeView(QtWidgets.QTreeView):
     def mouseDoubleClickEvent(self, event):
         return event.accept()
 
-    def setFilterRegExp(self, reg_exp):
-        self.model().setFilterRegExp(reg_exp)
+    def setFilterRegularExpression(self, reg_exp):
+        self.model().setFilterRegularExpression(reg_exp)
 
     def _handleMousePress(self, index):
         self._leftMouseButton = QtWidgets.QApplication.mouseButtons() == QtCore.Qt.LeftButton

--- a/src/mapclient/view/workflow/workflowwidget.py
+++ b/src/mapclient/view/workflow/workflowwidget.py
@@ -90,9 +90,8 @@ class WorkflowWidget(QtWidgets.QWidget):
         self._undoStack.indexChanged.connect(self.undoStackIndexChanged)
 
     def _filter_text_changed(self, text):
-        reg_exp = QtCore.QRegExp(text, QtCore.Qt.CaseInsensitive)
-        #         self._workflowManager.getFilteredStepModel().setFilterRegExp(reg_exp)
-        self._ui.stepTreeView.setFilterRegExp(reg_exp)
+        reg_exp = QtCore.QRegularExpression(text, QtCore.QRegularExpression.PatternOption.CaseInsensitiveOption)
+        self._ui.stepTreeView.setFilterRegularExpression(reg_exp)
 
     def _update_ui(self):
         if hasattr(self, '_main_window'):


### PR DESCRIPTION
I've noticed that the search bar in the MAP-Client workflow step widget isn't currently working due to the following PySide6 changes:

The `QRegExp` class was replaced with `QRegularExpression`. The `QSortFilterProxyModel` `setFilterRegExp` method has also been replaced by `setFilterRegularExpression`.

I've updated the code to use the correct classes/methods.