### PR TITLE
Bug fixes for 0.20.0

### DIFF
--- a/src/mapclient/tools/pluginfinder/downloadtodirectorydialog.py
+++ b/src/mapclient/tools/pluginfinder/downloadtodirectorydialog.py
@@ -4,7 +4,7 @@ import zipfile
 import requests
 
 from posixpath import join
-from PySide2.QtWidgets import QDialog, QFileDialog, QMessageBox
+from PySide6.QtWidgets import QDialog, QFileDialog, QMessageBox
 
 from mapclient.tools.pluginfinder.ui.ui_downloadtodirectorydialog import Ui_DownloadToDirectoryDialog
 

--- a/src/mapclient/tools/pluginfinder/plugindata.py
+++ b/src/mapclient/tools/pluginfinder/plugindata.py
@@ -64,6 +64,8 @@ class MAPPlugin:
 
 # This makes the MAPPlugin class compatible with workflowsteps.addStep().
 setattr(MAPPlugin, 'getName', MAPPlugin.get_name)
+setattr(MAPPlugin, 'getCategory', MAPPlugin.get_category)
+setattr(MAPPlugin, 'getIcon', lambda self: None)
 
 
 class PluginData(QtGui.QStandardItemModel):

--- a/src/mapclient/tools/pluginfinder/plugindata.py
+++ b/src/mapclient/tools/pluginfinder/plugindata.py
@@ -2,8 +2,8 @@ import os
 import json
 from packaging import version
 
-from PySide2 import QtCore, QtGui
-from PySide2.QtWidgets import QApplication, QStyle, QStyleOptionButton, QInputDialog, QLineEdit, QMessageBox, QTreeView
+from PySide6 import QtCore, QtGui
+from PySide6.QtWidgets import QApplication, QStyle, QStyleOptionButton, QInputDialog, QLineEdit, QMessageBox, QTreeView
 
 from mapclient.core.workflow.workflowsteps import addStep
 from mapclient.view.workflow.workflowsteptreeview import HeaderDelegate, WorkflowStepTreeView

--- a/src/mapclient/tools/pluginfinder/pluginfinderdialog.py
+++ b/src/mapclient/tools/pluginfinder/pluginfinderdialog.py
@@ -6,8 +6,8 @@ Author: Timothy Salemink
 
 from packaging import version
 
-from PySide2 import QtCore, QtGui
-from PySide2.QtWidgets import QDialog, QLabel, QPushButton, QMessageBox
+from PySide6 import QtCore, QtGui
+from PySide6.QtWidgets import QDialog, QLabel, QPushButton, QMessageBox
 
 from mapclient.tools.pluginfinder.plugindata import get_plugin_database, PushButtonDelegate, PluginData
 from mapclient.core.workflow.workflowsteps import WorkflowStepsFilter
@@ -121,12 +121,12 @@ class PluginFinderDialog(QDialog):
         self._ui.lineEditFilter.textChanged.connect(self._filter_text_changed)
 
     def _filter_text_changed(self, text):
-        reg_exp = QtCore.QRegExp(text, QtCore.Qt.CaseInsensitive)
-        self._ui.stepTreeView.setFilterRegExp(reg_exp)
+        reg_exp = QtCore.QRegularExpression(text, QtCore.QRegularExpression.PatternOption.CaseInsensitiveOption)
+        self._ui.stepTreeView.setFilterRegularExpression(reg_exp)
 
     def _update_available_steps(self):
         self._plugin_data.reload()
-        self._filtered_plugins.sort(QtCore.Qt.AscendingOrder)
+        self._filtered_plugins.sort(1, QtCore.Qt.AscendingOrder)
 
     def _expand_step_tree(self):
         self._ui.stepTreeView.expandAll()

--- a/src/mapclient/tools/pluginfinder/ui/ui_downloadtodirectorydialog.py
+++ b/src/mapclient/tools/pluginfinder/ui/ui_downloadtodirectorydialog.py
@@ -3,15 +3,21 @@
 ################################################################################
 ## Form generated from reading UI file 'downloadtodirectorydialog.ui'
 ##
-## Created by: Qt User Interface Compiler version 5.15.2
+## Created by: Qt User Interface Compiler version 6.5.1
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
 
-from PySide2.QtCore import *
-from PySide2.QtGui import *
-from PySide2.QtWidgets import *
-
+from PySide6.QtCore import (QCoreApplication, QDate, QDateTime, QLocale,
+    QMetaObject, QObject, QPoint, QRect,
+    QSize, QTime, QUrl, Qt)
+from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
+    QFont, QFontDatabase, QGradient, QIcon,
+    QImage, QKeySequence, QLinearGradient, QPainter,
+    QPalette, QPixmap, QRadialGradient, QTransform)
+from PySide6.QtWidgets import (QApplication, QComboBox, QDialog, QGroupBox,
+    QHBoxLayout, QLabel, QPushButton, QSizePolicy,
+    QSpacerItem, QVBoxLayout, QWidget)
 
 class Ui_DownloadToDirectoryDialog(object):
     def setupUi(self, DownloadToDirectoryDialog):

--- a/src/mapclient/tools/pluginfinder/ui/ui_pluginfinderdialog.py
+++ b/src/mapclient/tools/pluginfinder/ui/ui_pluginfinderdialog.py
@@ -3,17 +3,23 @@
 ################################################################################
 ## Form generated from reading UI file 'pluginfinderdialog.ui'
 ##
-## Created by: Qt User Interface Compiler version 5.15.2
+## Created by: Qt User Interface Compiler version 6.5.1
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
 
-from PySide2.QtCore import *
-from PySide2.QtGui import *
-from PySide2.QtWidgets import *
+from PySide6.QtCore import (QCoreApplication, QDate, QDateTime, QLocale,
+    QMetaObject, QObject, QPoint, QRect,
+    QSize, QTime, QUrl, Qt)
+from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
+    QFont, QFontDatabase, QGradient, QIcon,
+    QImage, QKeySequence, QLinearGradient, QPainter,
+    QPalette, QPixmap, QRadialGradient, QTransform)
+from PySide6.QtWidgets import (QAbstractItemView, QApplication, QDialog, QHBoxLayout,
+    QHeaderView, QLineEdit, QSizePolicy, QSplitter,
+    QVBoxLayout, QWidget)
 
 from mapclient.tools.pluginfinder.plugindata import PluginTreeView
-
 
 class Ui_PluginFinderDialog(object):
     def setupUi(self, PluginFinderDialog):

--- a/src/setup.py
+++ b/src/setup.py
@@ -41,7 +41,8 @@ package_dependencies = [
     'pmr2.client >= 0.2',
     'packaging',
     'filelock',
-    'psutil == 5.9.3'
+    'psutil == 5.9.3',
+    'PyGithub'
 ]
 
 extras_require = {


### PR DESCRIPTION
This PR addresses bugs related to the Plugin Finder tool introduced in [this PR](https://github.com/MusculoskeletalAtlasProject/mapclient/pull/60).

Since the original PR was submitted prior to the migration to PySide6, I have had to make some changes to the tool to upgrade it from PySide2.

Some changes have also been made to the `MAPPlugin` class utilised by the Plugin Finder tool. The `MAPPlugin` class was originally created to mimic the `WorkflowStepMountPoint`, which would allow us to use the existing `addStep` function to add "plugin-like" objects to the Plugin Finder GUI. Since there have been updates to the `WorkflowStepMountPoint` and the `addStep` method since the PR was submitted, changes are now required to maintain the existing functionality. Obviously this current implementation isn't very robust. When I get a chance I will look at updating the way the Plugin Finder populates the `QListView` so that it doesn't rely on the `addStep` method.