### PR TITLE
Fix undo/redo actions for workflow connections

### DIFF
--- a/src/mapclient/view/workflow/workflowgraphicsitems.py
+++ b/src/mapclient/view/workflow/workflowgraphicsitems.py
@@ -508,7 +508,8 @@ class StepPort(QtWidgets.QGraphicsEllipseItem):
         return False
 
     def addArc(self, arc):
-        self._connections.append(weakref.ref(arc))
+        if not weakref.ref(arc) in self._connections:
+            self._connections.append(weakref.ref(arc))
 
     def removeArc(self, arc):
         self._connections = [weakarc for weakarc in self._connections if weakarc() != arc]

--- a/src/mapclient/view/workflow/workflowgraphicsscene.py
+++ b/src/mapclient/view/workflow/workflowgraphicsscene.py
@@ -60,7 +60,11 @@ class WorkflowGraphicsScene(QtWidgets.QGraphicsScene):
     def addItem(self, item):
         QtWidgets.QGraphicsScene.addItem(self, item)
         if hasattr(item, 'Type'):
-            if item.Type == Node.Type or item.Type == Arc.Type:
+            if item.Type == Node.Type:
+                self._workflow_scene.addItem(item.metaItem())
+            elif item.Type == Arc.Type:
+                item.sourceNode().addArc(item)
+                item.destinationNode().addArc(item)
                 self._workflow_scene.addItem(item.metaItem())
 
     def removeItem(self, item):


### PR DESCRIPTION
This PR addresses issue #82.

The `addItem` method which is called by the undo/redo actions must explicitly call `addArc` to ensure any `Arc` connections removed by `removeItem` are correctly reinstated.