### PR TITLE
Identify PMR workflows before committing changes

### DIFF
--- a/src/mapclient/tools/pmr/pmrtool.py
+++ b/src/mapclient/tools/pmr/pmrtool.py
@@ -124,6 +124,11 @@ class PMRTool(object):
     PROTOCOL = 'application/vnd.physiome.pmr2.json.0'
     UA = 'pmr.jsonclient.Client/0.2'
 
+    PMR_URLS = [
+        "https://models.physiomeproject.org/workspace",
+        "https://teaching.physiomeproject.org/workspace"
+    ]
+
     def __init__(self, pmr_info=None, use_external_git=False):
         self._termLookUpLimit = 32
         self.set_info(pmr_info)
@@ -387,15 +392,20 @@ class PMRTool(object):
         # Do the writing.
         cmd.write_remote(workspace)
 
-    def hasDVCS(self, local_workspace_dir):
+    def is_pmr_workflow(self, local_workspace_dir):
         git_dir = os.path.join(local_workspace_dir, '.git')
         if os.path.isdir(git_dir):
             bob = get_cmd_by_name(self._git_implementation)()
             workspace = CmdWorkspace(local_workspace_dir, bob)
-            return workspace.cmd is not None
+            if workspace.cmd is None:
+                return False
+
+            remote_workspace_url = workspace.cmd.read_remote(workspace)
+            url = remote_workspace_url[:remote_workspace_url.rfind('/')]
+            return url in self.PMR_URLS
+
         else:
             return False
-
 
     def commitFiles(self, local_workspace_dir, message, files):
         workspace = CmdWorkspace(local_workspace_dir, get_cmd_by_name(self._git_implementation)())

--- a/src/mapclient/tools/pmr/pmrtool.py
+++ b/src/mapclient/tools/pmr/pmrtool.py
@@ -25,6 +25,7 @@ import os.path
 from requests import HTTPError
 from requests import Session
 from requests_oauthlib import OAuth1Session
+from urllib.parse import urlparse
 
 from pmr2.wfctrl.core import get_cmd_by_name
 from pmr2.wfctrl.core import CmdWorkspace
@@ -123,11 +124,6 @@ class PMRTool(object):
 
     PROTOCOL = 'application/vnd.physiome.pmr2.json.0'
     UA = 'pmr.jsonclient.Client/0.2'
-
-    PMR_URLS = [
-        "https://models.physiomeproject.org/workspace",
-        "https://teaching.physiomeproject.org/workspace"
-    ]
 
     def __init__(self, pmr_info=None, use_external_git=False):
         self._termLookUpLimit = 32
@@ -401,11 +397,13 @@ class PMRTool(object):
                 return False
 
             remote_workspace_url = workspace.cmd.read_remote(workspace)
-            url = remote_workspace_url[:remote_workspace_url.rfind('/')]
-            return url in self.PMR_URLS
+            url_parsed = urlparse(remote_workspace_url)
+            for host_domain in self._pmr_info.hosts():
+                host_parsed = urlparse(host_domain)
+                if url_parsed.netloc == host_parsed.netloc:
+                    return True
 
-        else:
-            return False
+        return False
 
     def commitFiles(self, local_workspace_dir, message, files):
         workspace = CmdWorkspace(local_workspace_dir, get_cmd_by_name(self._git_implementation)())

--- a/src/mapclient/view/workflow/workflowwidget.py
+++ b/src/mapclient/view/workflow/workflowwidget.py
@@ -558,7 +558,7 @@ class WorkflowWidget(QtWidgets.QWidget):
         om = self._main_window.model().optionsManager()
         pmr_info = PMR()
         pmr_tool = PMRTool(pmr_info, use_external_git=om.getOption(USE_EXTERNAL_GIT))
-        if not pmr_tool.hasDVCS(workflowDir):
+        if not pmr_tool.is_pmr_workflow(workflowDir):
             # nothing to commit.
             return True
 
@@ -614,7 +614,7 @@ class WorkflowWidget(QtWidgets.QWidget):
         pmr_info = PMR()
         pmr_tool = PMRTool(pmr_info, use_external_git=om.getOption(USE_EXTERNAL_GIT))
 
-        if not pmr_tool.hasDVCS(workflow_dir):
+        if not pmr_tool.is_pmr_workflow(workflow_dir):
             return
         try:
             pmr_tool.addFileToIndexer(workflow_dir, DEFAULT_WORKFLOW_ANNOTATION_FILENAME)


### PR DESCRIPTION
This PR addresses issue #81.

The `hasDVCS` method has been renamed to `is_pmr_workflow`. This method now additionally checks if the Git URL associated with the workflow is part of the PMR-workspace namespace.

Since both uses of the `hasDVCS` method are called when determining whether to submit workflow changes to PMR, it is important that we differentiate between workflows version controlled by PMR and workflows that are version controlled by other means.