### PR TITLE
Bug fix for import config dialog

### DIFF
--- a/src/mapclient/view/workflow/importconfigdialog.py
+++ b/src/mapclient/view/workflow/importconfigdialog.py
@@ -129,7 +129,7 @@ class ImportConfigDialog(QtWidgets.QDialog):
 
                         self._graphics_scene.setConfigureNode(node_dict[identifier])
 
-                        configuration = load_configuration(temp_dir, identifier)
+                        configuration = load_configuration(temp_dir, current_text)
                         step_dict[identifier].deserialize(configuration)
 
                         for additional_cfg_file in step_dict[identifier].getAdditionalConfigFiles():


### PR DESCRIPTION
This PR addresses issue #85.

The incorrect value was being passed to the `load_configuration` function. This will correctly import the step name and configuration settings even when the step identifiers don't match.