### PR TITLE
Update PMR workflow import and update actions

### DIFF
--- a/src/mapclient/tools/pmr/settings/general.py
+++ b/src/mapclient/tools/pmr/settings/general.py
@@ -20,6 +20,8 @@ This file is part of MAP Client. (http://launchpad.net/mapclient)
 
 from PySide6 import QtCore
 
+from mapclient.tools.pmr.core import DEFAULT_SITE_URL, TEACHING_SITE_URL
+
 # Credentials follows:
 #
 # Key    OP8AKmDIlH7OkHaPWNbnb-zf
@@ -38,7 +40,6 @@ from PySide6 import QtCore
 
 class PMR(object):
 
-    DEFAULT_PMR_IPADDRESS = 'http://teaching.physiomeproject.org'
     DEFAULT_CONSUMER_PUBLIC_TOKEN = 'OP8AKmDIlH7OkHaPWNbnb-zf'
     DEFAULT_CONSUMER_SECRET_TOKEN = 'QQcKMnyCjjb7JNDHA-Lwdu7p'
 
@@ -50,10 +51,10 @@ class PMR(object):
         settings = QtCore.QSettings()
         settings.beginGroup('PMR')
         # pmr_host?  this is a domain name...
-        self._active_host = settings.value('active-pmr-website', self.DEFAULT_PMR_IPADDRESS)
+        self._active_host = settings.value('active-pmr-website', TEACHING_SITE_URL)
         self._consumer_public_token = settings.value('consumer-public-token', self.DEFAULT_CONSUMER_PUBLIC_TOKEN)
         self._consumer_secret_token = settings.value('consumer-secret-token', self.DEFAULT_CONSUMER_SECRET_TOKEN)
-        
+
         size = settings.beginReadArray('instances')
         for i in range(size):
             settings.setArrayIndex(i)
@@ -64,6 +65,8 @@ class PMR(object):
         settings.endArray()
         
         settings.endGroup()
+        if size == 0:
+            self.addHost(DEFAULT_SITE_URL)
         self.addHost(self._active_host)
 
     def writeSettings(self):

--- a/src/mapclient/tools/pmr/widgets/workspacewidget.py
+++ b/src/mapclient/tools/pmr/widgets/workspacewidget.py
@@ -32,7 +32,6 @@ class WorkspaceWidget(QtWidgets.QWidget):
         import_layout.addStretch(1)
 
         self._update_button = QtWidgets.QPushButton("Update")
-        self._update_button.setEnabled(False)
         update_layout = QtWidgets.QHBoxLayout()
         update_layout.addWidget(self._update_button)
         update_layout.addStretch(1)


### PR DESCRIPTION
References to the old PMR endpoint have been removed. When the user opens the _PMR Tool_ for the first time, both the default _models_ endpoint and the _teaching_ endpoint will be added to the list of hosts for the _PMR Tool_, the _teaching_ endpoint will be selected as the active host by default.

With these changes in effect, we can successfully _Import_ and _Update_ workflows from PMR.