### PR TITLE
Update PMR Import Dialog

### DIFF
--- a/src/mapclient/tools/pmr/qt/pmrworkflowwidget.ui
+++ b/src/mapclient/tools/pmr/qt/pmrworkflowwidget.ui
@@ -104,7 +104,11 @@
            </widget>
           </item>
           <item>
-           <widget class="QLineEdit" name="lineEditWorkspace"/>
+           <widget class="QLineEdit" name="lineEditWorkspace">
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+           </widget>
           </item>
          </layout>
         </item>

--- a/src/mapclient/tools/pmr/ui/ui_pmrworkflowwidget.py
+++ b/src/mapclient/tools/pmr/ui/ui_pmrworkflowwidget.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'pmrworkflowwidget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.4.1
+## Created by: Qt User Interface Compiler version 6.5.1
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -81,6 +81,7 @@ class Ui_PMRWorkflowWidget(object):
 
         self.lineEditWorkspace = QLineEdit(self.groupBox)
         self.lineEditWorkspace.setObjectName(u"lineEditWorkspace")
+        self.lineEditWorkspace.setReadOnly(True)
 
         self.horizontalLayout.addWidget(self.lineEditWorkspace)
 

--- a/src/mapclient/tools/pmr/widgets/workspacewidget.py
+++ b/src/mapclient/tools/pmr/widgets/workspacewidget.py
@@ -65,6 +65,7 @@ class WorkspaceWidget(QtWidgets.QWidget):
 
     def update_from_pmr(self):
         self._update_from_pmr()
+        self._workflow_widget.reload()
 
     @handle_runtime_error
     @set_wait_cursor

--- a/src/mapclient/view/workflow/workflowwidget.py
+++ b/src/mapclient/view/workflow/workflowwidget.py
@@ -459,6 +459,10 @@ class WorkflowWidget(QtWidgets.QWidget):
         om = self._main_window.model().optionsManager()
         om.setOption(PREVIOUS_WORKFLOW, workflow_dir)
 
+    def reload(self):
+        m = self._main_window.model().workflowManager()
+        self._load(m.location())
+
     def close(self):
         self._main_window.confirm_close()
         m = self._main_window.model().workflowManager()


### PR DESCRIPTION
This PR updates the PMR Tool.

The _Update_ action now reloads the current workflow after pulling the repository from Git.

Additionally, the _Workspace_ line edit in the PMR import dialog has been made read-only, as this value should reflect the workspace selection that the user has made and probably wasn't intended to be editable.