### PR TITLE
Fix import dialog ZIP identification

### DIFF
--- a/src/mapclient/view/workflow/workflowwidget.py
+++ b/src/mapclient/view/workflow/workflowwidget.py
@@ -597,7 +597,7 @@ class WorkflowWidget(QtWidgets.QWidget):
     def import_cfg(self):
         m = self._main_window.model().workflowManager()
         import_source, _ = QtWidgets.QFileDialog.getOpenFileName(self._main_window, caption='Select Import File', dir=m.previousLocation(),
-                                                                 filter=f"Data files(*.zip);MAP Client Project file({DEFAULT_WORKFLOW_PROJECT_FILENAME})")
+                                                                 filter=f"MAP Client Project file({DEFAULT_WORKFLOW_PROJECT_FILENAME} *.zip)")
 
         if len(import_source) > 0:
             dlg = ImportConfigDialog(import_source, self._graphicsScene, self)

--- a/src/mapclient/view/workflow/workflowwidget.py
+++ b/src/mapclient/view/workflow/workflowwidget.py
@@ -597,7 +597,7 @@ class WorkflowWidget(QtWidgets.QWidget):
     def import_cfg(self):
         m = self._main_window.model().workflowManager()
         import_source, _ = QtWidgets.QFileDialog.getOpenFileName(self._main_window, caption='Select Import File', dir=m.previousLocation(),
-                                                                 filter=f"MAP Client Project file({DEFAULT_WORKFLOW_PROJECT_FILENAME} *.zip)")
+                                                                 filter=f"Data files(*.zip);;MAP Client Project file({DEFAULT_WORKFLOW_PROJECT_FILENAME})")
 
         if len(import_source) > 0:
             dlg = ImportConfigDialog(import_source, self._graphicsScene, self)


### PR DESCRIPTION
This PR ensures that both `.proj` and `.zip` files are visible and selectable when using the _Import Workflow Configuration_ dialog. The current code is only recognising `.proj` files.