### PR TITLE
Remove automatic push to PMR on workflow save

### DIFF
--- a/src/mapclient/view/workflow/workflowwidget.py
+++ b/src/mapclient/view/workflow/workflowwidget.py
@@ -530,7 +530,7 @@ class WorkflowWidget(QtWidgets.QWidget):
 
     @handle_runtime_error
     @set_wait_cursor
-    def _commitChanges(self, workflowDir, comment, commit_local=False):
+    def _commitChanges(self, workflowDir, comment):
         committed_changes = False
         om = self._main_window.model().optionsManager()
         pmr_info = PMR()
@@ -554,8 +554,6 @@ class WorkflowWidget(QtWidgets.QWidget):
                         workflow_files.extend(get_steps_additional_config_files(item.getStep()))
 
             pmr_tool.commit_files(workflowDir, comment, workflow_files)
-            if not commit_local:
-                pmr_tool.pushToRemote(workflowDir)
             committed_changes = True
         except ClientRuntimeError:
             # handler will deal with this.


### PR DESCRIPTION
When saving a PMR workflow we should commit the changes automatically but only push the changes to PMR if the user chooses to do so explicitly. The "Update" button in the PMR Tool "Workspace" tab has been renamed to "Pull" and a "Push" button has also been added.

@hsorby, previously the "Update" command would have ensured that the local repository was in-sync with the PMR repository. Now, since it is possible to have un-pushed commits locally, the "Pull" command will not necessarily guarantee that the local repository matches the one on PMR. If I push a workflow to PMR manually, then save some additional changes locally, then pull from PMR: the workflow will maintain the local commits. This is consistent with standard Git pull procedure. But I'm wondering if we might also want an additional command that syncs the local repository with the remote - since command line options to discard recent commits, etc. are not accessible from the PMR Tool UI. Or perhaps we could open an additional "advanced pull" dialog in the case where there are commits locally?