### PR TITLE
Add functionality to sans GUI main that allows users to run a workflow

### DIFF
--- a/src/mapclient/core/importexport.py
+++ b/src/mapclient/core/importexport.py
@@ -1,0 +1,27 @@
+import os
+from tempfile import TemporaryDirectory
+from zipfile import is_zipfile, ZipFile
+
+from PySide6 import QtCore
+
+from mapclient.settings.info import DEFAULT_WORKFLOW_PROJECT_FILENAME
+
+
+def import_settings(source_location):
+    """
+    Get the project information from the source location whether it is a
+    Zip file or directory.
+
+    :param source_location: A Zip file or directory.
+    :return: A QtCore.QSettings object.
+    """
+    if is_zipfile(source_location):
+        # Get project information for the imported workflow.
+        with ZipFile(source_location) as archive:
+            with TemporaryDirectory() as temp_dir:
+                archive.extract(DEFAULT_WORKFLOW_PROJECT_FILENAME, temp_dir)
+                import_proj = QtCore.QSettings(os.path.join(temp_dir, DEFAULT_WORKFLOW_PROJECT_FILENAME), QtCore.QSettings.Format.IniFormat)
+    else:
+        import_proj = QtCore.QSettings(source_location, QtCore.QSettings.Format.IniFormat)
+
+    return import_proj

--- a/src/mapclient/core/managers/workflowmanager.py
+++ b/src/mapclient/core/managers/workflowmanager.py
@@ -25,7 +25,7 @@ from PySide6 import QtCore
 
 from mapclient.core.metrics import metrics_logger
 from mapclient.settings import info
-from mapclient.core.workflow.workflowscene import WorkflowScene
+from mapclient.core.workflow.workflowscene import WorkflowScene, read_steps, load_from
 from mapclient.core.workflow.workflowsteps import WorkflowSteps, \
     WorkflowStepsFilter
 from mapclient.core.workflow.workflowerror import WorkflowError
@@ -193,6 +193,17 @@ class WorkflowManager(object):
         wf.setValue('version', info.VERSION_STRING)
         wf.setValue('id', info.DEFAULT_WORKFLOW_PROJECT_IDENTIFIER)
         return wf
+
+    @staticmethod
+    def list_steps(location):
+        wf = _get_workflow_configuration(location)
+        return read_steps(wf)
+
+    @staticmethod
+    def load_steps(location):
+        WorkflowManager._check_workflow_location(location)
+        wf = _get_workflow_configuration(location)
+        return load_from(wf, location)
 
     def new(self, location):
         """

--- a/src/mapclient/core/utils.py
+++ b/src/mapclient/core/utils.py
@@ -26,16 +26,12 @@ import sys
 from pathlib import Path, PureWindowsPath
 
 from subprocess import Popen, PIPE, DEVNULL
-from tempfile import TemporaryDirectory
-from zipfile import ZipFile, is_zipfile
 
 import PySide6 as RefMod
-from PySide6 import QtCore
 
 from mapclient.mountpoints.workflowstep import workflowStepFactory
 from mapclient.settings.definitions import APPLICATION_NAME, PLUGINS_PACKAGE_NAME
 from mapclient.settings.general import get_configuration_file
-from mapclient.settings.info import DEFAULT_WORKFLOW_PROJECT_FILENAME
 
 logger = logging.getLogger(__name__)
 

--- a/src/mapclient/core/workflow/workflowscene.py
+++ b/src/mapclient/core/workflow/workflowscene.py
@@ -60,6 +60,21 @@ def _read_step_names(ws):
     return step_names
 
 
+def read_steps(wf):
+    wf.beginGroup('nodes')
+    node_count = wf.beginReadArray('nodelist')
+
+    step_data = list()
+    for i in range(node_count):
+        wf.setArrayIndex(i)
+        step_data.append((wf.value('name'), wf.value('identifier')))
+
+    wf.endArray()
+    wf.endGroup()
+
+    return step_data
+
+
 def get_step_name_from_identifier(ws, target_identifier):
     ws.beginGroup('nodes')
     step_name = ''
@@ -78,6 +93,31 @@ def get_step_name_from_identifier(ws, target_identifier):
     ws.endGroup()
 
     return step_name
+
+
+def load_from(wf, location):
+    steps = []
+    wf.beginGroup('nodes')
+    node_count = wf.beginReadArray('nodelist')
+    for node_index in range(node_count):
+        wf.setArrayIndex(node_index)
+        name = wf.value('name')
+        identifier = wf.value('identifier')
+        step = workflowStepFactory(name, location)
+        step.setIdentifier(identifier)
+        configuration = load_configuration(location, identifier)
+
+        def _mock_identifier_occurs_count(arg):
+            return 1
+
+        step._identifierOccursCount = _mock_identifier_occurs_count
+        step.deserialize(configuration)
+        steps.append(step)
+
+    wf.endArray()
+    wf.endGroup()
+
+    return steps
 
 
 def create_from(wf, name_identifiers, connections, location):

--- a/src/mapclient/mountpoints/workflowstep.py
+++ b/src/mapclient/mountpoints/workflowstep.py
@@ -281,7 +281,11 @@ def _get_additional_config_files(self):
 
 
 def _workflow_step_set_configuration(self, configuration):
-    pass
+    raise NotImplementedError
+
+
+def _workflow_step_relocate_configuration(self, to_location):
+    raise NotImplementedError
 
 
 attr_dict = {
@@ -304,6 +308,7 @@ attr_dict = {
     'registerConfiguredObserver': _workflow_step_registerConfiguredObserver,
     'registerIdentifierOccursCount': _workflow_step_registerIdentifierOccursCount,
     'registerOnExecuteEntry': _workflow_step_registerOnExecuteEntry,
+    'relocateConfiguration': _workflow_step_relocate_configuration,
     'serialize': _workflow_step_serialize,
     'setConfiguration': _workflow_step_set_configuration,
     'setLocation': _workflow_step_setLocation,

--- a/src/mapclient/view/workflow/importconfigdialog.py
+++ b/src/mapclient/view/workflow/importconfigdialog.py
@@ -6,31 +6,12 @@ from packaging import version
 from tempfile import TemporaryDirectory
 from zipfile import is_zipfile, ZipFile
 
+from mapclient.core.importexport import import_settings
 from mapclient.settings.info import VERSION_STRING, DEFAULT_WORKFLOW_PROJECT_FILENAME
 from mapclient.core.utils import load_configuration, copy_step_additional_config_files
 from mapclient.core.workflow.workflowitems import MetaStep
 from mapclient.view.workflow.workflowgraphicsitems import Node
 from mapclient.view.workflow.ui.ui_importconfigdialog import Ui_ImportConfigDialog
-
-
-def _import_settings(source_location):
-    """
-    Get the project information from the source location whether it is a
-    Zip file or directory.
-
-    :param source_location: A Zip file or directory.
-    :return: A QtCore.QSettings object.
-    """
-    if is_zipfile(source_location):
-        # Get project information for the imported workflow.
-        with ZipFile(source_location) as archive:
-            with TemporaryDirectory() as temp_dir:
-                archive.extract(DEFAULT_WORKFLOW_PROJECT_FILENAME, temp_dir)
-                import_proj = QtCore.QSettings(os.path.join(temp_dir, DEFAULT_WORKFLOW_PROJECT_FILENAME), QtCore.QSettings.Format.IniFormat)
-    else:
-        import_proj = QtCore.QSettings(source_location, QtCore.QSettings.Format.IniFormat)
-
-    return import_proj
 
 
 class ImportConfigDialog(QtWidgets.QDialog):
@@ -97,7 +78,7 @@ class ImportConfigDialog(QtWidgets.QDialog):
             self._step_map["Selected"] = import_steps["ID"]
 
     def is_compatible(self):
-        import_proj = _import_settings(self._import_source)
+        import_proj = import_settings(self._import_source)
         # Check for version compatibility.
         import_version = version.parse(import_proj.value('version'))
         application_version = version.parse(VERSION_STRING)
@@ -109,7 +90,7 @@ class ImportConfigDialog(QtWidgets.QDialog):
         return True
 
     def _setup_step_map(self):
-        import_proj = _import_settings(self._import_source)
+        import_proj = import_settings(self._import_source)
 
         node_count = len([_ for _ in self._workflow_scene.items() if (_.Type == MetaStep.Type)])
         import_steps = self._determine_import_steps(import_proj)


### PR DESCRIPTION
Adds ability to apply configuration changes from within a zipped archive of MAP Client project configuration files.  
Also allows for relocating configuration parameters that rely on a relative path to correctly identify the target.
Currently only
* File Chooser
* Directory Copy
support this functionality, further support is to be added on a needs must basis.