### PR TITLE
Fix `hiddenimports` for mapping-tools build

### DIFF
--- a/res/pyinstaller/hooks/hook-mapclientplugins.py
+++ b/res/pyinstaller/hooks/hook-mapclientplugins.py
@@ -1,5 +1,22 @@
+import json
+import os
+
 from PyInstaller.utils.hooks import collect_submodules
 
+hooks_dir = os.path.dirname(__file__)
+plugin_paths_file = os.path.join(hooks_dir, '..', 'mapclientplugins_paths.json')
 
-# I don't think this will work if the plugin is zipped in an archive.
-hiddenimports = collect_submodules('mapclientplugins')
+if os.path.isfile(plugin_paths_file):
+    with open(plugin_paths_file) as f:
+        plugin_paths = json.load(f)
+
+    hiddenimports = []
+    for plugin_path in plugin_paths:
+        mapclientplugins_dir = os.path.join(plugin_path, 'mapclientplugins')
+        if os.path.isdir(mapclientplugins_dir):
+            for name in os.listdir(mapclientplugins_dir):
+                if os.path.isdir(os.path.join(mapclientplugins_dir, name)) and not name.startswith('_'):
+                    hiddenimports.append(f'mapclientplugins.{name}')
+else:
+    # Fallback for manual builds without the paths JSON; collects any installed mapclientplugins.
+    hiddenimports = collect_submodules('mapclientplugins')


### PR DESCRIPTION
When upgrading to PyInstaller 6.21.0 (from 6.16.0), `collect_submodules('mapclientplugins')` no longer resolves the `mapclientplugins` namespace package, whose plugins are spread across multiple editable-install paths. As a result, it silently discovers no submodules and bundles zero plugins.

The hook now reads `mapclientplugins_paths.json` and enumerates plugin packages directly. This is probably a more reliable approach than relying on PyInstaller's namespace-package discovery, since this manifest is already generated during the build and lists exactly the plugins that were prepared.